### PR TITLE
AWS IoT now requires clientId

### DIFF
--- a/javasource/mqttclient/impl/MqttConnector.java
+++ b/javasource/mqttclient/impl/MqttConnector.java
@@ -95,7 +95,7 @@ public class MqttConnector {
             	clientId = "a:" + brokerOrganisation + ":" + xasId;
             }else{
             	broker = String.format("tcp://%s:%d", brokerHost, brokerPort);
-                clientId = "MxClient_" + xasId + "_" + hostname + "_" + brokerHost + "_" + brokerPort;
+                clientId = "bluemix-receiver";
             }
             logger.info("new MqttConnection client id " + clientId);
 


### PR DESCRIPTION
AWS IoT worked with this module before but it now requires clientId.
To make it enable, my change is:

MqttConnector.java

            // clientId = "MxClient_" + xasId + "_" + hostname + "_" + brokerHost + "_" + brokerPort;
            clientId = "bluemix-receiver";

This solution is just temporal.  It is much better to accept clientId for setting from Mendix widget.